### PR TITLE
Remove click. Tag v0.4.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ COPY osmtogtfs /build/osmtogtfs/
 COPY setup.py README.md /build/
 RUN python3 setup.py install
 RUN find /usr/lib/ -name libboost_* -not -name libboost_python* -delete
-RUN pip install click
 RUN find /usr/lib/python3.6 -type f -name "*.pyc" -delete
 RUN find /usr/lib/ -name "__pycache__" -type d -delete
 
@@ -20,7 +19,7 @@ COPY --from=0 /usr/lib/libboost_python3.so* \
 COPY --from=0 /usr/lib/python3.6/site-packages/ /usr/lib/python3.6/site-packages/
 COPY --from=0 /usr/bin/o2g /usr/bin/o2g
 
-RUN pip --no-cache-dir install --no-compile flask validators requests click
+RUN pip --no-cache-dir install --no-compile flask validators requests
 
 ENV LC_ALL=C.UTF-8
 WORKDIR /app

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,6 @@ name = "pypi"
 
 [packages]
 osmium = "*"
-click = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "aa470bf6b2677661e418b9e6e9fb1e2e049a0b0c1cba57d73cf3bceb5fbcfd98"
+            "sha256": "845bd76be4b85a5d1377c07a5c785bfd422822cd0ee928d0b7626a77f278b716"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,14 +14,6 @@
         ]
     },
     "default": {
-        "click": {
-            "hashes": [
-                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
-                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
-            ],
-            "index": "pypi",
-            "version": "==7.0"
-        },
         "osmium": {
             "hashes": [
                 "sha256:1da881ca783946936e901dc32d0a3c1765c8d75904a66350852abb792246d3fd",

--- a/osmtogtfs/__init__.py
+++ b/osmtogtfs/__init__.py
@@ -1,0 +1,6 @@
+"""
+osmtogtfs is a tool to extract public transport information from OpenStreetMap
+data. osmtogtfs comes with a client tool called o2g.
+"""
+
+__version__ = "0.4.0"

--- a/osmtogtfs/cli.py
+++ b/osmtogtfs/cli.py
@@ -10,45 +10,77 @@ from logging import FileHandler
 from contextlib import contextmanager
 from pathlib import Path
 
-import click
+import argparse
 
+from osmtogtfs import __version__
 from osmtogtfs.gtfs import gtfs_dummy
 from osmtogtfs.gtfs.gtfs_writer import GTFSWriter
 from osmtogtfs.osm.exporter import TransitDataExporter
 
 
-@click.command()
-@click.argument('osmfile', type=click.Path(exists=True, readable=True))
-@click.option('--outdir', default='.',
-              type=click.Path(exists=True,
-                              dir_okay=True,
-                              writable=True,
-                              resolve_path=True),
-              help='Output directory. Default is the current directory.')
-@click.option('--zipfile',
-              type=click.Path(),
-              help='Save to zipfile. Default is saving to flat text files.')
-@click.option('--dummy/--no-dummy',
-              default=False,
-              help='Whether to fill the missing parts with dummy data.')
-# @click.option('--with-frequencies',
-#               is_flag=True,
-#               help='Generate frequencies.')
-@click.option('--loglevel',
-              default='WARNING',
-              type=click.Choice(['DEBUG', 'INFO', 'WARNING', 'ERROR',
-                                 'CRITICAL']),
-              help="Set the logging level")
-@click.version_option(None, '-v', '--version')
-def cli(osmfile, outdir, zipfile, dummy, loglevel):
-    if loglevel:
-        logging.basicConfig(level=loglevel)
-    logging.debug('Input: %s', osmfile)
-    logging.debug('Output: %s', outdir)
-    logging.debug('Zip?: %s', zipfile or False)
-    logging.debug('Dummy?: %s', dummy)
+class readable_dir(argparse.Action):
+    def __call__(self, parser, namespace, prospective_dir, option_string=None):
+        if not os.path.isdir(prospective_dir):
+            parser.print_usage()
+            print('Try "{} --help" for help.\n'.format(parser.prog))
+            parser.exit("Error: Inavlid path: {0}".format(prospective_dir))
+        if os.access(prospective_dir, os.R_OK):
+            setattr(namespace, self.dest, prospective_dir)
+        else:
+            parser.print_usage()
+            print('Try "{} --help" for help.\n'.format(parser.prog))
+            parser.exit("Error: Unreadable dir: {0}".format(prospective_dir))
 
-    main(osmfile, outdir, zipfile, dummy)
+
+class readable_file(argparse.Action):
+    def __call__(self, parser, namespace, prospective_file, option_string=None):
+        if not os.path.isfile(prospective_file):
+            parser.print_usage()
+            print('Try "{} --help" for help.\n'.format(parser.prog))
+            parser.exit("Error: Inavlid file: {0}".format(prospective_file))
+        if os.access(prospective_file, os.R_OK):
+            setattr(namespace, self.dest, prospective_file)
+        else:
+            parser.print_usage()
+            print('Try "{} --help" for help.\n'.format(parser.prog))
+            parser.exit("Error: Unreadable file: {0}".format(prospective_file))
+
+
+def cli():
+    parser = argparse.ArgumentParser(
+        prog='o2g',
+        epilog='Here is a smile for you :)',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description='Export GTFS feed from OpenStreetMap data.')
+    parser.add_argument('osmfile', metavar='OSMFILE', action=readable_file,
+                        help='an OSM data file supported by osmium')
+    parser.add_argument('--outdir', action=readable_dir,
+                        default='.',
+                        help='output directory')
+    parser.add_argument('--zipfile', action='store_true',
+                        default=False,
+                        help='save to zipfile')
+    parser.add_argument('--dummy', action='store_true',
+                        default=False,
+                        help='fill the missing parts with dummy data')
+    parser.add_argument('--loglevel',
+                        default='WARNING',
+                        help='set the logging level')
+    parser.add_argument('--version',
+                        action='version',
+                        version='%(prog)s ' + __version__,
+                        help='Show the version and exit')
+
+    args = parser.parse_args()
+
+    if args.loglevel:
+        logging.basicConfig(level=args.loglevel)
+    logging.debug('Input: %s', args.osmfile)
+    logging.debug('Output: %s', args.outdir)
+    logging.debug('Zip?: %s', args.zipfile or False)
+    logging.debug('Dummy?: %s', args.dummy)
+
+    main(args.osmfile, args.outdir, args.zipfile, args.dummy)
 
 
 def main(osmfile, outdir, zipfile, dummy):
@@ -83,10 +115,10 @@ def main(osmfile, outdir, zipfile, dummy):
 
     if zipfile:
         writer.write_zipped(os.path.join(outdir, zipfile))
-        click.echo('GTFS feed saved in %s' % os.path.join(outdir, zipfile))
+        print('GTFS feed saved in %s' % os.path.join(outdir, zipfile))
     else:
         writer.write_unzipped(outdir)
-        click.echo('GTFS feed saved in %s' % outdir)
+        print('GTFS feed saved in %s' % outdir)
 
     logging.debug('Done in %d seconds.', (time.time() - start))
 

--- a/osmtogtfs/cli.py
+++ b/osmtogtfs/cli.py
@@ -65,7 +65,7 @@ def cli():
                         help='fill the missing parts with dummy data')
     parser.add_argument('--loglevel',
                         default='WARNING',
-                        help='set the logging level')
+                        help='DEBUG, INFO, WARNING, ERROR or CRITICAL')
     parser.add_argument('--version',
                         action='version',
                         version='%(prog)s ' + __version__,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-click
 osmium

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 from setuptools import setup, find_packages
 
+from osmtogtfs import __version__
+
 
 def readme():
     with open('README.md') as f:
@@ -7,7 +9,7 @@ def readme():
 
 
 setup(name='osmtogtfs',
-      version='0.3.3',
+      version=__version__,
       description='Extracts partial GTFS feed from OSM data.',
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -25,7 +27,7 @@ setup(name='osmtogtfs',
       },
       zip_safe=False,
       test_suite='pytest',
-      install_requires=['osmium', 'setuptools', 'click'],
+      install_requires=['osmium'],
       classifiers=['Development Status :: 4 - Beta',
                    'Environment :: Console',
                    'Intended Audience :: End Users/Desktop',


### PR DESCRIPTION
I removed yet another dependency. What I was doing with click could be achieved with standard library functionality. Moreover, osmtogtfs is a package so it makes little sense for it to depend on a cli building package.