### PR TITLE
appjson

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,6 @@ deploy:
     tags: true
     python: 3.6
     branch: master
-# - provider: script
-#   script: bash scripts/deploy.sh
-#   on:
-#     branch: master
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ deploy:
     tags: true
     python: 3.6
     branch: master
-- provider: script
-  script: bash scripts/deploy.sh
-  on:
-    branch: master
+# - provider: script
+#   script: bash scripts/deploy.sh
+#   on:
+#     branch: master
 addons:
   apt:
     packages:

--- a/app.json
+++ b/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "osmtogtfs",
+  "stack": "container"
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-docker login -u _ -p "$HEROKU_TOKEN"  registry.heroku.com
-docker build -t registry.heroku.com/o2g/web .
-docker push registry.heroku.com/o2g/web


### PR DESCRIPTION
Removing app.json disabled review apps (not heroku deploy), so I have to put it back. Moreover, the docker build in travis was useless, since heroku builds it. Hence disabling it.